### PR TITLE
Add reactivity to combobox

### DIFF
--- a/src/Combobox.php
+++ b/src/Combobox.php
@@ -41,7 +41,6 @@ class Combobox extends Select
         $values = collect($values)->pluck('value')->toArray();
         $this->state($values);
         $this->callAfterStateUpdated();
-        // checking correct version pulled
     }
 
     public function isMultiple(): bool

--- a/src/Combobox.php
+++ b/src/Combobox.php
@@ -41,6 +41,7 @@ class Combobox extends Select
         $values = collect($values)->pluck('value')->toArray();
         $this->state($values);
         $this->callAfterStateUpdated();
+        // checking correct version pulled
     }
 
     public function isMultiple(): bool

--- a/src/Combobox.php
+++ b/src/Combobox.php
@@ -40,6 +40,7 @@ class Combobox extends Select
     {
         $values = collect($values)->pluck('value')->toArray();
         $this->state($values);
+        $this->callAfterStateUpdated();
     }
 
     public function isMultiple(): bool


### PR DESCRIPTION
Currently the afterStateUpdated method is not ran when items are moved between the options and selected items. Adding this makes the field reactive and other fields can be updated based on the current selection